### PR TITLE
Fix if the openScope doesn´t exist anymore

### DIFF
--- a/ui-bootstrap-tpls.js
+++ b/ui-bootstrap-tpls.js
@@ -1652,9 +1652,11 @@ angular.module('ui.bootstrap.dropdown', [])
         return;
     }
 
-    openScope.$apply(function() {
-      openScope.isOpen = false;
-    });
+    if ( openScope ) {
+      openScope.$apply(function() {
+        openScope.isOpen = false;
+      });
+    }
   };
 
   var escapeKeyBind = function( evt ) {


### PR DESCRIPTION
If the dropdown is not available in the DOM anymore but with the $document.bind the click event will be called it creates an error as you can´t $apply on a "null" element. This resolves the problem.
