### PR TITLE
chore: add description and keywords for better searchability

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,12 @@
         "name": "https://github.com/angular-ui/bootstrap/graphs/contributors"
     },
     "name": "angular-bootstrap",
+    "keywords": [
+        "angular",
+        "angular-ui",
+        "bootstrap"
+    ],
+    "description": "Native AngularJS (Angular) directives for Bootstrap.",
     "version": "0.11.2",
     "main": ["./ui-bootstrap-tpls.js"],
     "dependencies": {


### PR DESCRIPTION
Looks like bower.io searches the keywords and typing "angular bootstrap" or "angular-ui bootstrap" doesn't return this package in the results.
