### PR TITLE
NPM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "angular-ui-bootstrap",
+    "version": "0.13.0",
+    "description": "Native AngularJS (Angular) directives for Bootstrap.",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/angular-ui/bootstrap-bower"
+    },
+    "author": {
+        "name": "https://github.com/angular-ui/bootstrap/graphs/contributors"
+    },
+    "keywords": [
+        "angular",
+        "angular-ui",
+        "bootstrap"
+    ],
+    "license": "MIT",
+    "ignore": [],
+    "main": "./ui-bootstrap-tpls.js",
+    "dependencies": {
+        "angular": "~1.3.13",
+        "bootstrap": "^3"
+    }
+}


### PR DESCRIPTION
With this, `npm install angular-ui/bootstrap-bower` becomes possible. This is of course only temporary until real NPM packages are managed by the Angular UI Bootstrap team.