### PR TITLE
Add ui-bootstrap.js to main in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,10 @@
     "ignore": [],
     "description": "Native AngularJS (Angular) directives for Bootstrap.",
     "version": "0.12.0",
-    "main": ["./ui-bootstrap-tpls.js"],
+    "main": [
+        "./ui-bootstrap.js",
+        "./ui-bootstrap-tpls.js"
+    ],
     "dependencies": {
         "angular": ">=1 <1.3.0"
     }    


### PR DESCRIPTION
IMHO, it doesn't make sense to just add the templates file when you install this dependency with bower, `ui-bootstrap.js` is also required.
