### PR TITLE
Update ui-bootstrap-tpls.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
     "author": {
-        "name": "https://github.com/angular-ui/bootstrap/graphs/contributors"
+        "name": "test"
     },
-    "name": "angular-bootstrap",
+    "name": "angular-test",
     "keywords": [
         "angular",
         "angular-ui",

--- a/ui-bootstrap-tpls.js
+++ b/ui-bootstrap-tpls.js
@@ -1520,7 +1520,7 @@ function ($compile, $parse, $document, $position, dateFilter, dateParser, datepi
 
       if ( attrs.datepickerOptions ) {
         var options = scope.$parent.$eval(attrs.datepickerOptions);
-        if(options.initDate) {
+        if( typeof options != 'undefined' && options.initDate ) {
           scope.initDate = options.initDate;
           datepickerEl.attr( 'init-date', 'initDate' );
           delete options.initDate;


### PR DESCRIPTION
If a user doesn't add the init-date directive for the Datepicker, the following error occurs:

`TypeError: Cannot read property 'initDate' of undefined` on line 1523 of ui-bootstrap-tpls.js.