### PR TITLE
Fix error in require syntax to make package work in jspm

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-require('./ui-bootstrap-tpls.js');
+require('./ui-bootstrap-tpls');
 module.exports = 'ui.bootstrap';


### PR DESCRIPTION
require('./ui-bootstrap-tpls.js') is wrong. it should not have a .js extension.

when I try to load the package in jspm, I am getting a 404 looking for ui-bootstrap-tpls.js.js