### PR TITLE
Add dependency on bootstrap.css file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
     "version": "0.13.3",
     "main": ["./ui-bootstrap-tpls.js"],
     "dependencies": {
-        "angular": ">=1.3.0"
+        "angular": ">=1.3.0",
+        "bootstrap-css-only": ">=2.0.0"
     }
 }


### PR DESCRIPTION
Update bower.json to add dependency on https://github.com/fyockm/bootstrap-css-only which holds bootstrap.css, to avoid installing regular bootstrap which depend on jQuery, or adding bootstrap.css manually.